### PR TITLE
use typed constants for the IPType

### DIFF
--- a/client.go
+++ b/client.go
@@ -21,9 +21,9 @@ type IPType uint8
 
 // Options for IPType.
 const (
-	IPv4        = 0x01
-	IPv6        = 0x02
-	IPv4AndIPv6 = (IPv4 | IPv6) //< Default option.
+	IPv4        IPType = 0x01
+	IPv6        IPType = 0x02
+	IPv4AndIPv6        = IPv4 | IPv6 // default option
 )
 
 // Client structure encapsulates both IPv4/IPv6 UDP connections.


### PR DESCRIPTION
This makes them render more nicely on GoDoc, grouped under the `IPType`:
![image](https://user-images.githubusercontent.com/1478487/129186108-90ee971b-8f11-40cd-9429-29c393da79cc.png)
