### PR TITLE
Don't stop browsing after ~15min

### DIFF
--- a/client.go
+++ b/client.go
@@ -368,6 +368,7 @@ func (c *client) periodicQuery(ctx context.Context, params *lookupParams) error 
 	bo := backoff.NewExponentialBackOff()
 	bo.InitialInterval = 4 * time.Second
 	bo.MaxInterval = 60 * time.Second
+	bo.MaxElapsedTime = 0
 	bo.Reset()
 
 	var timer *time.Timer
@@ -381,11 +382,8 @@ func (c *client) periodicQuery(ctx context.Context, params *lookupParams) error 
 		if err := c.query(params); err != nil {
 			return err
 		}
-		// Backoff and cancel logic.
+		// Backoff logic
 		wait := bo.NextBackOff()
-		if wait == backoff.Stop {
-			return fmt.Errorf("periodicQuery: abort due to timeout")
-		}
 		if timer == nil {
 			timer = time.NewTimer(wait)
 		} else {


### PR DESCRIPTION
I was surprised to discover that browse terminates, closing the entries channel, after ~15 minutes. Clearly, there was logic present handling the stop/timeout case in the original code. A simple repro can be achieved using the example:

```
time go run examples/resolv/client.go -wait 3600
2021/09/08 02:19:40 Failed to browse: periodicQuery: abort due to timeout
exit status 1
go run examples/resolv/client.go -wait 3600  0,39s user 0,17s system 0% cpu 14:45,19 total
```

I changed it the way I think is most intuitive, which is not timeout at all. My use case is a long-running application and while I could certainly browse multiple times, I don't see why. It looks like legacy from the original repo. Timeouts can be handled the usual way, using `context.WithTimeout`, if required.