### PR TITLE
fix delays when sending initial probe packets

### DIFF
--- a/server.go
+++ b/server.go
@@ -557,11 +557,14 @@ func (s *Server) probe() {
 
 	randomizer := rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	for i := 0; i < multicastRepetitions; i++ {
+	// Wait for a random duration uniformly distributed between 0 and 250 ms
+	// before sending the first probe packet.
+	time.Sleep(time.Duration(randomizer.Intn(250)) * time.Millisecond)
+	for i := 0; i < 3; i++ {
 		if err := s.multicastResponse(q, 0); err != nil {
 			log.Println("[ERR] zeroconf: failed to send probe:", err.Error())
 		}
-		time.Sleep(time.Duration(randomizer.Intn(250)) * time.Millisecond)
+		time.Sleep(250 * time.Millisecond)
 	}
 
 	// From RFC6762
@@ -720,7 +723,7 @@ func (s *Server) unicastResponse(resp *dns.Msg, ifIndex int, from net.Addr) erro
 func (s *Server) multicastResponse(msg *dns.Msg, ifIndex int) error {
 	buf, err := msg.Pack()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to pack msg %v: %w", msg, err)
 	}
 	if s.ipv4conn != nil {
 		var wcm ipv4.ControlMessage


### PR DESCRIPTION
From https://datatracker.ietf.org/doc/html/rfc6762#section-8.1:
> When ready to send its Multicast DNS probe packet(s) the host should
   first wait for a short random delay time, uniformly distributed in
   the range 0-250 ms.  This random delay is to guard against the case
   where several devices are powered on simultaneously, or several
   devices are connected to an Ethernet hub, which is then powered on,
   or some other external event happens that might cause a group of
   hosts to all send synchronized probes.
>
>  250 ms after the first query, the host should send a second; then,
   250 ms after that, a third.  If, by 250 ms after the third probe, no
   conflicting Multicast DNS responses have been received, the host may
   move to the next step, announcing.

Note that we don't properly distinguish between probing and announcing, and we don't do any conflict detection at all. This PR should still at least bring us closer to what the spec is saying, and hopefully help us resolve https://github.com/libp2p/go-libp2p/issues/1167.