### PR TITLE
Fix compatibility with some IoT devices using avahi 0.8-rc1

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -93,7 +93,7 @@ func joinUdp4Multicast(interfaces []net.Interface) (*ipv4.PacketConn, error) {
 		return nil, fmt.Errorf("udp4: failed to join any of these interfaces: %v", interfaces)
 	}
 
-	pkConn.SetMulticastTTL(255)
+	_ = pkConn.SetMulticastTTL(255)
 
 	return pkConn, nil
 }

--- a/connection.go
+++ b/connection.go
@@ -93,6 +93,8 @@ func joinUdp4Multicast(interfaces []net.Interface) (*ipv4.PacketConn, error) {
 		return nil, fmt.Errorf("udp4: failed to join any of these interfaces: %v", interfaces)
 	}
 
+	pkConn.SetMulticastTTL(255)
+
 	return pkConn, nil
 }
 

--- a/connection.go
+++ b/connection.go
@@ -62,6 +62,8 @@ func joinUdp6Multicast(interfaces []net.Interface) (*ipv6.PacketConn, error) {
 		return nil, fmt.Errorf("udp6: failed to join any of these interfaces: %v", interfaces)
 	}
 
+	_ = pkConn.SetMulticastHopLimit(255)
+
 	return pkConn, nil
 }
 


### PR DESCRIPTION
This fixes browse, lookup and also register not working properly with some devices running with avahi 0.8-rc1

The problem came up with Elli Charger wallboxes, which are using avahi 0.8-rc1 which couldn't be seen using this library and the device also didn't see the service announced with this library. Using avahi 0.8-rc1 on a linux device (ubuntu) does not show the same effects. So something within this device is causing this.

Upping the IPv4 TTL to 255 and the IPv6 HopLimit to 255 solves this. The avahi library also uses these values since almost 18 years and they haven't been changed.