### PR TITLE
Write deadlock fixes and overall reliability improvements

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -53,7 +53,7 @@ func joinUdp6Multicast(interfaces []*NetInterface) (*ipv6.PacketConn, error) {
 	var anySucceeded bool
 	for _, iface := range interfaces {
 		if err := pkConn.JoinGroup(&iface.Interface, &net.UDPAddr{IP: mdnsGroupIPv6}); err == nil {
-			iface.SetFlag(NetInterfaceScopeIPv6, NetInterfaceStateFlagJoined)
+			iface.SetFlag(NetInterfaceScopeIPv6, NetInterfaceStateFlagMulticastJoined)
 			anySucceeded = true
 		}
 	}
@@ -88,7 +88,7 @@ func joinUdp4Multicast(interfaces []*NetInterface) (*ipv4.PacketConn, error) {
 	for _, iface := range interfaces {
 		if err := pkConn.JoinGroup(&iface.Interface, &net.UDPAddr{IP: mdnsGroupIPv4}); err == nil {
 			anySucceed = true
-			iface.SetFlag(NetInterfaceScopeIPv4, NetInterfaceStateFlagJoined)
+			iface.SetFlag(NetInterfaceScopeIPv4, NetInterfaceStateFlagMulticastJoined)
 		}
 	}
 	if !anySucceed {

--- a/netinterface.go
+++ b/netinterface.go
@@ -22,8 +22,8 @@ type NetInterfaceList []*NetInterface
 type NetInterfaceStateFlag uint8
 
 const (
-	NetInterfaceStateFlagJoined NetInterfaceStateFlag = 1 << iota
-	NetInterfaceStateFlagRegistered
+	NetInterfaceStateFlagMulticastJoined NetInterfaceStateFlag = 1 << iota // we have joined the multicast group on this interface
+	NetInterfaceStateFlagMessageSent                                       // we have successfully sent at least one message on this interface
 )
 
 func (i *NetInterface) HasFlags(scope NetInterfaceScope, flags ...NetInterfaceStateFlag) bool {

--- a/netinterface.go
+++ b/netinterface.go
@@ -1,0 +1,71 @@
+package zeroconf
+
+import (
+	"net"
+)
+
+type NetInterface struct {
+	net.Interface
+	stateIPv4 NetInterfaceStateFlag
+	stateIPv6 NetInterfaceStateFlag
+}
+
+type NetInterfaceScope int
+
+const (
+	NetInterfaceScopeIPv4 NetInterfaceScope = iota
+	NetInterfaceScopeIPv6
+)
+
+type NetInterfaceList []*NetInterface
+
+type NetInterfaceStateFlag uint8
+
+const (
+	NetInterfaceStateFlagJoined NetInterfaceStateFlag = 1 << iota
+	NetInterfaceStateFlagRegistered
+)
+
+func (i *NetInterface) HasFlags(scope NetInterfaceScope, flags ...NetInterfaceStateFlag) bool {
+	for _, flag := range flags {
+		if !i.HasFlag(scope, flag) {
+			return false
+		}
+	}
+	return true
+}
+
+func (i *NetInterface) HasFlag(scope NetInterfaceScope, flag NetInterfaceStateFlag) bool {
+	if scope == NetInterfaceScopeIPv4 {
+		return i.stateIPv4&flag != 0
+	} else if scope == NetInterfaceScopeIPv6 {
+		return i.stateIPv6&flag != 0
+	}
+	return false
+}
+
+func (i *NetInterface) SetFlag(scope NetInterfaceScope, flag NetInterfaceStateFlag) {
+	if scope == NetInterfaceScopeIPv4 {
+		i.stateIPv4 |= flag
+		return
+	} else if scope == NetInterfaceScopeIPv6 {
+		i.stateIPv6 |= flag
+		return
+	}
+}
+
+func (list NetInterfaceList) GetByIndex(index int) *NetInterface {
+	for _, iface := range list {
+		if iface.Index == index {
+			return iface
+		}
+	}
+	return nil
+}
+
+func NewInterfaceList(ifaces []net.Interface) (list NetInterfaceList) {
+	for i := range ifaces {
+		list = append(list, &NetInterface{Interface: ifaces[i]})
+	}
+	return
+}

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,9 @@
 package zeroconf
 
-import "strings"
+import (
+	"strings"
+	"time"
+)
 
 func parseSubtypes(service string) (string, []string) {
 	subtypes := strings.Split(service, ",")
@@ -10,4 +13,16 @@ func parseSubtypes(service string) (string, []string) {
 // trimDot is used to trim the dots from the start or end of a string
 func trimDot(s string) string {
 	return strings.Trim(s, ".")
+}
+
+type DeadlineSetter interface {
+	SetWriteDeadline(time.Time) error
+}
+
+func setDeadline(timeout time.Duration, ds DeadlineSetter) {
+	if timeout != 0 {
+		ds.SetWriteDeadline(time.Now().Add(timeout))
+	} else {
+		ds.SetWriteDeadline(time.Time{})
+	}
 }


### PR DESCRIPTION
1. introduce writeTimeout for both server and clients
I have noticed that in some scenarios socket write([like here](https://github.com/libp2p/zeroconf/blob/master/server.go#L824)) can hang for indefinite time.
At least it reproducible in the latest MacOS release(13.2) when writing on some standard network interfaces.
In this case it blocks all the further writes to other interface and deadlock [Shutdown](https://github.com/libp2p/zeroconf/blob/master/server.go#L244) 
This PR introduce `WriteTimeout` and `ClientWriteTimeout` option with default of 10 sec. It seems to be much more than ok. In my case it either writes under 10ms or hangs indefinitely 

Overall if it will be timeout'ed we still have 3 tries in the probe


2. Introduce the proxy struct `NetInterface` that alongside the net.Interface stores the bitmask flags `MulticastJoined` and `MessageSent` separately for IPv6 and IPv4.
The reason behind this is that **multicastResponse** call without interface specified works in a way it iterates through all interface to send the message. This makes [unregister](https://github.com/libp2p/zeroconf/blob/master/server.go#L244)  tries to connect to interfaces that can be failed to join multicast group or send the announce.

On macOS I faced situations where some interface can join IPv6 multicast but can't join IPv4 multicast, or can announce on IPv6 but always hags(timeout) during announceText.

So `multicastResponse` now has an optional arguments to pass required flags

3. Add `ServerSelectIPTraffic` option similar to client's `SelectIPTraffic` option to disable IPv6 or IPv4 multicast.
This seems pretty useful to have, because you have no other way to control it, and IPv6 multicast may be more tricky to support
 
