### PR TITLE
allow advertising services on port 0

### DIFF
--- a/server.go
+++ b/server.go
@@ -66,9 +66,6 @@ func Register(instance, service, domain string, port int, text []string, ifaces 
 	if entry.Domain == "" {
 		entry.Domain = "local."
 	}
-	if entry.Port == 0 {
-		return nil, fmt.Errorf("missing port")
-	}
 
 	var err error
 	if entry.HostName == "" {
@@ -126,9 +123,6 @@ func RegisterProxy(instance, service, domain string, port int, host string, ips 
 	}
 	if entry.Domain == "" {
 		entry.Domain = "local"
-	}
-	if entry.Port == 0 {
-		return nil, fmt.Errorf("missing port")
 	}
 
 	if !strings.HasSuffix(trimDot(entry.HostName), entry.Domain) {


### PR DESCRIPTION
hey, thanks for maintaining this!

Here's a small (maybe annoying) fix:

https://datatracker.ietf.org/doc/html/rfc2782 allows for port numbers >= 0.

More specifically, https://www.rfc-editor.org/rfc/rfc6763.html states

<blockquote>
   If a device does not implement the flagship protocol, then it instead
   creates a placeholder SRV record (priority=0, weight=0, port=0,
   target host = host name of device) with that name.  If, when it
   attempts to create this SRV record, it finds that a record with the
   same name already exists, then it knows that this name is already
   taken by some other entity implementing at least one of the protocols
   from the fleet, and it must choose another.  If no SRV record already
   exists, then the act of creating it stakes a claim to that name so
   that future devices in the same protocol fleet will detect a conflict
   when they try to use it.
</blockquote>

In my case, I'm trying to implement an IPP Everywhere server, the [spec](https://ftp.pwg.org/pub/pwg/candidates/cs-ippeve11-20200515-5100.14.pdf#%5B%7B%22num%22%3A78%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C64%2C162%2C0%5D) for which states

<blockquote>
Printers that support DNS-SD MUST advertise the "_printer._tcp" (LPD) service over mDNS
in order to conform to the Flagship Naming requirements as defined in [RFC6763]. For
example, a Printer named "Example Printer" would advertise the service instance name
"Example Printer._printer._tcp.local." with a port number of 0 to indicate that the LPD
protocol is not actually supported.
</blockquote>

So.. any chance of removing the `port != 0` check? :)

Cheers again,
Jarrad