### PR TITLE
Cause cached entries to actually expire.

### DIFF
--- a/client.go
+++ b/client.go
@@ -277,6 +277,7 @@ func (c *client) mainloop(ctx context.Context, params *lookupParams) {
 					continue
 				}
 				if _, ok := sentEntries[k]; ok {
+					sentEntries[k].Expiry = e.Expiry
 					continue
 				}
 


### PR DESCRIPTION
I've tried using a few Golang libraries for mDNS in the past couple days. I found https://github.com/grandcat/zeroconf and then this one, and I noticed that this one actually does things with the TTLs returned with mDNS entries. That appears to be because this fork has [this commit](https://github.com/grandcat/zeroconf/commit/047d9a607fe481b8127b46712faf390f67adc32f), which the parent repo doesn't have.

When experimenting with it, I discovered that this updated TTL support doesn't quite work. Specifically, `(*client).mainloop` accumulates new responses into the `entries` map, and once it has sent information about a new service to the subscriber, it [stores a copy of it](https://github.com/libp2p/zeroconf/blob/master/client.go#L296) in the `sentEntries` map. It has [code](https://github.com/libp2p/zeroconf/blob/master/client.go#L194-L198) to delete entries from the `sentEntries` map once they expire. But if it receives updated information for an entry, it doesn't propagate the new `Expiry` time to the entry in `sentEntries`, so that entry will be missing between the expiry of the original message and when it receives a new message for it.

This PR has a simple fix for this - propagate the updated `Expiry` time from any new entries that it receives.

I've seen comments in other PRs saying "please submit this to the parent, we don't want to deal with the maintenance burden". As far as I can tell, this issue is specific to your fork, so I think this is the right place to send it. Also, if you don't want it, no worries.